### PR TITLE
Fix TypeError when processing individual .gtf files

### DIFF
--- a/src/eastr/output_utils.py
+++ b/src/eastr/output_utils.py
@@ -22,7 +22,7 @@ def out_junctions_filelist(bam_list:list, gtf_path, bed_list, out_junctions, suf
 
     if gtf_path:
         if utils.check_directory_or_file(out_junctions) == 'dir':
-            out_junctions= out_junctions + "/" + os.path.splitext(os.path.basename(gtf_path)[0]) + suffix + ".bed"
+            out_junctions= f"{out_junctions}/{os.path.splitext(os.path.basename(gtf_path))[0]}{suffix}.bed"
         return out_junctions
 
     if bed_list:


### PR DESCRIPTION
I ran EASTR the following way:
```shell
eastr --gtf .../transcripts.gtf --reference .../GCF_009914755.1_T2T-CHM13v2.0_alt_genomic.fna --bowtie2_index .../index
```
and got 
```
TypeError: can only concatenate str (not "tuple") to str
```
in this line. I figure it's because of an incorrectly placed parenthesis. Also switched the whole line to an f-string to match the style of other code in this file.